### PR TITLE
Don't mangle numeric lists!

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,5 +7,6 @@ README
 lib/Text/Autoformat.pm
 t/00.load.t
 t/01.ignore.t
+t/02.wide-numbers.t
 config.emacs
 config.vim

--- a/lib/Text/Autoformat.pm
+++ b/lib/Text/Autoformat.pm
@@ -507,8 +507,6 @@ sub _build_ignore {
     return $ignore;
 }
 
-use utf8;
-
 my $alpha = qr/[^\W\d_]/;
 my $notalpha = qr/[\W\d_]/;
 my $word = qr/\pL(?:\pL'?)*/;

--- a/lib/Text/Autoformat.pm
+++ b/lib/Text/Autoformat.pm
@@ -520,7 +520,6 @@ sub recase {
 
     my $text = "";
     my @pieces = split /(&[a-z]+;)/i, $origtext;
-    use Data::Dumper 'Dumper';
     push @pieces, "" if @pieces % 2;
     return $text unless @pieces;
     local $_ = shift @pieces;

--- a/lib/Text/Autoformat.pm
+++ b/lib/Text/Autoformat.pm
@@ -673,7 +673,7 @@ sub toRoman($$)
 
 # BITS OF A NUMERIC VALUE
 
-my $num = q/(?:\d{1,3}\b(?!:\d\d\b))/;     # Ignore 8:20 etc.
+my $num = q/(?:[0-9]{1,3}\b(?!:[0-9][0-9]\b))/;     # Ignore 8:20 etc.
 my $let = q/[A-Za-z]/;
 my $pbr = q/[[(<]/;
 my $sbr = q/])>/;

--- a/t/02.wide-numbers.t
+++ b/t/02.wide-numbers.t
@@ -1,0 +1,24 @@
+use utf8;
+use strict;
+use Test::More tests => 1;
+use Text::Autoformat;
+
+my $str = <<'END';
+１. Analyze problem
+２. Design algorithm
+６. Code solution
+４. Test
+２. Ship
+END
+
+my $after = autoformat $str, {
+  lists => 'number',
+  all   => 1, # rjbs thinks this should not be needed -- rjbs, 2015-04-24
+};
+
+unlike(
+  $after,
+  qr/2/,
+  "we do not mangle lists numbered with non-ASCII numbers",
+);
+


### PR DESCRIPTION
Given a list like this:

> 1. foo
> 2. bar
> 3. baz

You should get:

> 1. foo
> 2. bar
> 3. baz

…and you do.  If you use non-ASCII number characters, though, it gets mucked up.  I'll use "full width" Arabic numerals here, for easy reading by Western eyes.  Given this input:

> １. foo
> ３. bar
> ２. baz

…we get this output:

> １. foo
> 1. bar
> 2. baz

The first digit is kept as a number, but then we try adding 1 to it, and it's treated like a bogus string and we get a non-numeric warning and 1.  Because non-number plus 1 is 1.  Ho ho!

This branch just stops trying to handle these.  For now!
