### PR TITLE
Fix formatting of lists with "0" at the end of them

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module Text::Autoformat
 
+1.75 2019-08-13 ROBM
+    - Correctly handle lists with "0" on the end of them to preserve
+      the "0" rather than dropping it
+
 1.74 2015-11-28 NEILB
     - On Perl 5.22+ you could get "Negative repeat count does nothing"
       warnings. Thanks to SREZIC for RT#109838.

--- a/lib/Text/Autoformat/Hang.pm
+++ b/lib/Text/Autoformat/Hang.pm
@@ -85,7 +85,7 @@ sub new {
                 : ($lists_mode =~ /1|alpha/i && $_[1] =~ s#\A($let(?!$let))##i)
                         ? { type=>'let', val=>$1 }
                 :         { val => "", type => "" };
-            $_[1] = $pre.$_[1] and last unless $val->{val};
+            $_[1] = $pre.$_[1] and last unless length $val->{val};
             $val->{post} = $pre && $_[1] =~ s#\A($ows()[.:/]?[$close{$pre}][.:/]?)## && $1
                              || $_[1] =~ s#\A($ows()[$sbr.:/])## && $1
                              || "";

--- a/t/03.zero-number.t
+++ b/t/03.zero-number.t
@@ -1,0 +1,31 @@
+use utf8;
+use strict;
+use Test::More tests => 2;
+use Text::Autoformat;
+
+my $str = <<'END';
+1. Analyze problem
+0. Design algorithm
+3. Code solution
+END
+
+my $after = autoformat $str, { lists => 'number', all => 1 }; 
+
+is(
+  $after,
+  "1. Analyze problem\n2. Design algorithm\n3. Code solution\n",
+  "do not lose 0 in list"
+);
+
+$str = <<'END';
+4.0 Analyze problem
+END
+
+$after = autoformat $str, { lists => 'number', all => 1 }; 
+
+is(
+  $after,
+  "4.0 Analyze problem\n",
+  "do not lose 0 at end of list"
+);
+


### PR DESCRIPTION
This is a simple fix to handle lists with a "0" on the end of them. Currently autoformat on:
```
1.2.0 some stuff
```
Results in:
```
1.2. some stuff
```
I'm pretty sure this is a simple truthiness test issue, rather then length test. I've added a fix and a test to see that it works.