### PR TITLE
cope with non-ASCII in bullet lists

### DIFF
--- a/lib/Text/Autoformat.pm
+++ b/lib/Text/Autoformat.pm
@@ -181,7 +181,7 @@ sub autoformat  # ($text, %args)
 
             $lines[-1]{hang} = Text::Autoformat::Hang->new($_, $args{lists});
 
-            s/([ \t]*)(.*?)(\s*)$//
+            s/([ \x{A0}\t]*)(.*?)(\s*)$//
                 or die "Internal Error ($@) on '$_'";
             $lines[-1]{hangspace} = defn $1;
             $lines[-1]{text} = defn $2;

--- a/lib/Text/Autoformat/Hang.pm
+++ b/lib/Text/Autoformat/Hang.pm
@@ -4,6 +4,8 @@ use 5.006;
 use strict;
 use warnings;
 
+use utf8;
+
 # ROMAN NUMERALS
 
 sub inv($@) { my ($k, %inv)=shift; for(0..$#_) {$inv{$_[$_]}=$_*$k} %inv }
@@ -46,8 +48,8 @@ my %close = ( '[' => ']', '(' => ')', '<' => '>', "" => '' );
 my $hangPS      = qq{(?i:ps:|(?:p\\.?)+s\\b\\.?(?:[ \\t]*:)?)};
 my $hangNB      = qq{(?i:n\\.?b\\.?(?:[ \\t]*:)?)};
 my $hangword    = qq{(?:(?:Note)[ \\t]*:)};
-my $hangbullet  = qq{[*.+-]};
-my $hang        = qq{(?:(?i)(?:$hangNB|$hangword|$hangbullet)(?=[ \t]))};
+my $hangbullet  = qq{[•*.+-]};
+my $hang        = qq{(?:(?i)(?:$hangNB|$hangword|$hangbullet)(?=[ \x{A0}\t]))};
 
 # IMPLEMENTATION
 

--- a/t/04.non-ascii.t
+++ b/t/04.non-ascii.t
@@ -1,0 +1,19 @@
+use utf8;
+use strict;
+use Test::More tests => 1;
+use Text::Autoformat;
+
+# Possibly I'm breaking this on EBCDIC… -- rjbs, 2020-10-01
+my $NBSP = "\x{A0}";
+
+my $str = <<"END";
+•${NBSP}Analyze problem
+•${NBSP}Design algorithm
+• Code solution
+• Test
+• Ship
+END
+
+my $after = autoformat $str;
+
+is($after, $str, 'we treat \N{BULLET} as a bullet and NBSP after it as space');


### PR DESCRIPTION
This is two changes based on real-life data I'm formatting.

1.  accept that "•" is as much a bullet as "*" or "+"
2.  accept that a NBSP after a bullet is still a space; it's fine that it's NBSP, because we don't break there anyway!